### PR TITLE
Changed element.classList to element.className to allow IE9 and lower for compatibility

### DIFF
--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -94,7 +94,7 @@
 
         //remove 'currentTrack' CSS class
         for(var i=0; i<trackCount; i++){
-            if(tracks[i].classList.contains('currentTrack')){
+            if (tracks[i].className.indexOf('currentTrack') !== -1) {
                 tracks[i].className=tracks[i].className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
             }
         }


### PR DESCRIPTION
Currently this doesn't work for IE9 and lower.  This proposed change will make it work with IE9 and lower and Chrome and Mozilla.

Instead, use:
if (tracks[i].className.indexOf('currentTrack') !== -1) {
