### PR TITLE
Fixed hashing (loading video from URL hash), support for 'data-type' parameter and add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "videojs-playlist-audio",
+  "homepage": "https://github.com/tim-peterson/videojs-playlist",
+  "main": [
+    "javascripts/videojs.playlist.js"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "videojs-playlist-audio",
   "homepage": "https://github.com/tim-peterson/videojs-playlist",
   "main": [
-    "javascripts/videojs.playlist.js"
+    "javascripts/videojs.playlist.js",
+    "stylesheets/videojs.playlist.css"
   ]
 }

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -2,7 +2,7 @@
 
  videojs.plugin('playlist', function(options) {
   //this.L="vjs_common_one";
-  
+
 
   //console.log(this);
   var id=this.el().id;
@@ -75,12 +75,12 @@
 
       //remove 'currentTrack' CSS class
       for (var i=0; i<trackCount; i++){
-          if (tracks[i].className.indexOf('currentTrack') !== -1) {
-              tracks[i].className=tracks[i].className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
+          if (tracks[i].parentNode.className.indexOf('currentTrack') !== -1) {
+              tracks[i].parentNode.className = tracks[i].parentNode.className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
           }
       }
       //add 'currentTrack' CSS class
-      track.className = track.className + " currentTrack";
+      track.parentNode.className = track.className + " currentTrack";
       if (typeof onTrackSelected === 'function') {
         onTrackSelected.apply(track);
       }

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -58,12 +58,16 @@
       //get new src
       var src = track.getAttribute('data-src');
       type = track.getAttribute('data-type');
+      poster = track.getAttribute('data-poster');
       index = parseInt(track.getAttribute('data-index')) || index;
       //console.log('track select click src:'+src);
 
       player.src([
         {type: type, src: src}
       ]);
+
+      // set our poster
+      player.poster(poster);
 
       if (play) {
         player.play();

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -4,7 +4,7 @@
   //this.L="vjs_common_one";
   
 
-  console.log(this);
+  //console.log(this);
   var id=this.el().id;
 
   //console.log('begin playlist plugin with video id:'+id);
@@ -12,17 +12,17 @@
  //console.log(this);
   //var id=this.tag.id;
   //assign variables
-  var tracks=document.querySelectorAll("#"+id+"-vjs-playlist .vjs-track"),
-      trackCount=tracks.length,
-      player=this,
-      currentTrack=tracks[0],
-      index=0,
-      play=true,
-      onTrackSelected=options.onTrackSelected;
+  var tracks = document.querySelectorAll("#"+id+"-vjs-playlist .vjs-track"),
+      trackCount = tracks.length,
+      player = this,
+      currentTrack = tracks[0],
+      index = 0,
+      play = true,
+      onTrackSelected = options.onTrackSelected;
 
     //manually selecting track
-    for(var i=0; i<trackCount; i++){
-       tracks[i].onclick = function(){
+    for(var i=0; i<trackCount; i++) {
+       tracks[i].onclick = function() {
           //var track=this;
           //index=this.getAttribute('data-index');
           //console.log("a is clicked and index position is"+this.getAttribute('data-index')+"the data-src is "+this.getAttribute('data-src'));
@@ -33,14 +33,14 @@
     }
 
     // for continuous play
-    if(typeof options.continuous=='undefined' || options.continuous==true){
+    if (typeof options.continuous == 'undefined' || options.continuous == true) {
         //console.log('options.continuous==true');
 
-        player.on("ended", function(){
+        player.on("ended", function() {
             //console.log('on ended');
 
             index++;
-            if(index>=trackCount){
+            if (index>=trackCount) {
               //console.log('go to beginning');
               index=0;
             }
@@ -52,75 +52,60 @@
     else;// console.log('dont play next!');
 
     //track select function for onended and manual selecting tracks
-    var trackSelect=function(track){
+    var trackSelect = function(track) {
+      //console.log(track);
 
-       //get new src
-        var src=track.getAttribute('data-src');
-        index=parseInt(track.getAttribute('data-index')) || index;
-        //console.log('track select click src:'+src);
+      if (track instanceof MouseEvent) {
+        track = this;
+      }
 
-        if(player.techName=='youtube'){
-           player.src([
-            { type: type="video/youtube", src:  src}
-          ]);
-        }
-        else{
+      //get new src
+      var src = track.getAttribute('data-src');
+      type = track.getAttribute('data-type');
+      index = parseInt(track.getAttribute('data-index')) || index;
+      //console.log('track select click src:'+src);
 
-            if(player.el().firstChild.tagName=="AUDIO" || (typeof options.mediaType!='undefined' && options.mediaType=="audio") ){
+      player.src([
+        {type: type, src: src}
+      ]);
 
-              player.src([
-                  { type: "audio/mp4", src:  src+".m4a" },
-                  { type: "audio/webm", src: src+".webm" },
-                  { type: type="video/youtube", src:  src},
-                  { type: "audio/ogg", src: src+".ogg" }
-                  /*{ type: "audio/mpeg", src:  src+".mp3" },
-                  { type: "audio/ogg", src: src+".oga" }*/
-               ]);
-            }
-            else{
-            //console.log("video");
-              player.src([                
-                { type: "video/mp4", src:  src+".mp4" },
-                { type: type="video/youtube", src:  src},
-                { type: "video/webm", src: src+".webm" }
-                //{ type: "video/ogv", src: src+".ogv" }
-              ]);
-            }
-        }
+      if (play) {
+        player.play();
+      }
 
+      //remove 'currentTrack' CSS class
+      for (var i=0; i<trackCount; i++){
+          if (tracks[i].className.indexOf('currentTrack') !== -1) {
+              tracks[i].className=tracks[i].className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
+          }
+      }
+      //add 'currentTrack' CSS class
+      track.className = track.className + " currentTrack";
+      if (typeof onTrackSelected === 'function') {
+        onTrackSelected.apply(track);
+      }
 
+    } // end trackSelect
 
-        if(play) player.play();
-
-        //remove 'currentTrack' CSS class
-        for(var i=0; i<trackCount; i++){
-            if (tracks[i].className.indexOf('currentTrack') !== -1) {
-                tracks[i].className=tracks[i].className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
-            }
-        }
-        //add 'currentTrack' CSS class
-        track.className = track.className + " currentTrack";
-        if(typeof onTrackSelected === 'function') onTrackSelected.apply(track);
-
-    }
-
-    //if want to start at track other than 1st track
-    if(typeof options.setTrack!='undefined' ){
+    //if we want to start at track other than 1st track
+    if (typeof options.setTrack !='undefined' ){
       options.setTrack=parseInt(options.setTrack);
-      currentTrack=tracks[options.setTrack];
-      index=options.setTrack;
-      play=false;
+      currentTrack = tracks[options.setTrack];
+      index = options.setTrack;
+      play = false;
       //console.log('options.setTrack index'+index);
       trackSelect(tracks[index]);
-      play=true;
+      play = true;
     }
     if (window.location.hash) {
-      var hash = window.location.hash.substring(9);
+      var hash = window.location.hash.substring(0);
+      var track = document.body.querySelectorAll('*[href="' + hash + '"]')[0];
+      //console.log(track);
       play = false;
-      trackSelect(tracks[hash]);
+      trackSelect(track);
     }
 
-    var data={
+    var data = {
       tracks: tracks,
       trackCount: trackCount,
       play:function(){
@@ -130,19 +115,19 @@
         return index;
       },
       prev:function(){
-        var j=index-1;
+        var j = index-1;
         //console.log('j'+j);
         if(j<0 || j>trackCount) j=0;
         trackSelect(tracks[j]);
       },
       next:function(){
-        var j=index+1;
+        var j = index+1;
         //console.log('j'+j);
         if(j<0 || j>trackCount) j=0;
         trackSelect(tracks[j]);
       }
     };
     return data;
-});
+  });
 //return videojsplugin;
 })();

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -2,7 +2,7 @@
 
  videojs.plugin('playlist', function(options) {
   //this.L="vjs_common_one";
-
+  
 
   //console.log(this);
   var id=this.el().id;
@@ -75,12 +75,12 @@
 
       //remove 'currentTrack' CSS class
       for (var i=0; i<trackCount; i++){
-          if (tracks[i].parentNode.className.indexOf('currentTrack') !== -1) {
-              tracks[i].parentNode.className = tracks[i].parentNode.className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
+          if (tracks[i].className.indexOf('currentTrack') !== -1) {
+              tracks[i].className = tracks[i].className.replace(/\bcurrentTrack\b/,'nonPlayingTrack');
           }
       }
       //add 'currentTrack' CSS class
-      track.parentNode.className = track.className + " currentTrack";
+      track.className = track.className + " currentTrack";
       if (typeof onTrackSelected === 'function') {
         onTrackSelected.apply(track);
       }

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -55,10 +55,6 @@
     var trackSelect = function(track) {
       //console.log(track);
 
-      if (track instanceof MouseEvent) {
-        track = this;
-      }
-
       //get new src
       var src = track.getAttribute('data-src');
       type = track.getAttribute('data-type');

--- a/javascripts/videojs.playlist.js
+++ b/javascripts/videojs.playlist.js
@@ -2,7 +2,7 @@
 
  videojs.plugin('playlist', function(options) {
   //this.L="vjs_common_one";
-  
+
 
   //console.log(this);
   var id=this.el().id;
@@ -85,11 +85,11 @@
         onTrackSelected.apply(track);
       }
 
-    } // end trackSelect
+    }; // end trackSelect
 
     //if we want to start at track other than 1st track
     if (typeof options.setTrack !='undefined' ){
-      options.setTrack=parseInt(options.setTrack);
+      options.setTrack = parseInt(options.setTrack);
       currentTrack = tracks[options.setTrack];
       index = options.setTrack;
       play = false;
@@ -117,13 +117,13 @@
       prev:function(){
         var j = index-1;
         //console.log('j'+j);
-        if(j<0 || j>trackCount) j=0;
+        if( j<0 || j>trackCount ) j = 0;
         trackSelect(tracks[j]);
       },
       next:function(){
         var j = index+1;
         //console.log('j'+j);
-        if(j<0 || j>trackCount) j=0;
+        if(j<0 || j>trackCount) j = 0;
         trackSelect(tracks[j]);
       }
     };


### PR DESCRIPTION
I have written (what I think is) a better solution for loading videos from the URL hash.
```
if (window.location.hash) {
      var hash = window.location.hash.substring(0);
      var track = document.body.querySelectorAll('*[href="' + hash + '"]')[0];
      play = false;
      trackSelect(track);
    }
```
Line 3 of the above changes grabs the first (it should be the only if track hrefs are unique) 'a' tag it finds with the URL hash and loads it. Line 2 is also a modification in that it grabs the whole URL hash (instead of starting at position 10 which it did in the original code) which I think is a better solution for all.

Additionally, I have added a bower.json so that anybody importing the repo via Bower and using a gulp build script (or similar) will have the necessary components (the js and css) automatically included (these are listed in the "main" component of that file) in their build.

Lastly, I added support for supplying a 'data-type' parameter for each track to allow greater support for mixing and matching sources. These are simply added into the playlist HTML.
E.g.
```
<li><a class="vjs-track" href="#example-video-hash" data-index="0" data-src="https://www.youtube.com/watch?v=4YQRwGCZhL8" data-type="video/youtube"><img width="50" height="50" src="/images/example.jpg">Example Video Title</a></li>
```